### PR TITLE
Three new SSL-related options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ Pass these `Chuckle::Client.new`:
 
 * **cache_dir** (~/.chuckle) - where chuckle should cache files. If HOME doesn't exist or isn't writable, it'll use `/tmp/chuckle` instead
 * **cache_errors** (true) - false to not cache errors on disk (timeouts, http status >= 400, etc.)
+* **cacert** (nil) - cacert option to pass to curl
+* **capath** (nil) - capath option to pass to curl
 * **cookies** (false) - true to turn on cookie support
 * **expires_in** (:never) - time in seconds after which cache files should expire, or `:never` to never expire
+* **insecure** (false) - true to allow insecure SSL connections
 * **nretries** (2) - number of times to retry a failing request
 * **rate_limit** (1) - number of seconds between requests
 * **timeout** (30) - timeout per request. Note that if `nretries` is 2 and `timeout` is 30, a failing request could take 90 seconds to truly fail.

--- a/lib/chuckle/curl.rb
+++ b/lib/chuckle/curl.rb
@@ -79,6 +79,11 @@ module Chuckle
         command += ["--cookie-jar", cookie_jar.path]
       end
 
+      # SSL options
+      command += ["--cacert", client.cacert] if client.cacert
+      command += ["--capath", client.capath] if client.capath
+      command += ["--insecure"] if client.insecure?
+
       command += ["--dump-header", headers_path]
       command += ["--output", body_path]
 

--- a/lib/chuckle/options.rb
+++ b/lib/chuckle/options.rb
@@ -3,8 +3,11 @@ module Chuckle
     DEFAULT_OPTIONS = {
       cache_dir: nil,
       cache_errors: true,
+      cacert: nil,
+      capath: nil,
       cookies: false,
       expires_in: :never,
+      insecure: false,
       nretries: 2,
       rate_limit: 1,
       timeout: 30,
@@ -33,6 +36,16 @@ module Chuckle
       options[:cache_errors]
     end
 
+    # cacert to pass to curl
+    def cacert
+      options[:cacert]
+    end
+
+    # capath to pass to curl
+    def capath
+      options[:capath]
+    end
+
     # are cookies enabled?
     def cookies?
       options[:cookies]
@@ -41,6 +54,11 @@ module Chuckle
     # number of seconds to cache responses and cookies, or :never
     def expires_in
       options[:expires_in]
+    end
+
+    # allow insecure SSL connections?
+    def insecure?
+      options[:insecure]
     end
 
     # number of retries to attempt

--- a/test/test_network.rb
+++ b/test/test_network.rb
@@ -54,6 +54,16 @@ class TestNetwork < Minitest::Test
     assert !File.exists?(cookie_jar), "cookie jar should've expired"
   end
 
+  def test_https
+    response = client.get("https://httpbin.org/get")
+    assert_equal 200, response.code
+  end
+
+  def test_https_insecure
+    response = client(insecure: true).get("https://httpbin.org/get")
+    assert_equal 200, response.code
+  end
+
   def test_bin
     Dir.chdir(File.expand_path("../", __FILE__))
     assert_command("../bin/chuckle url_file.txt")


### PR DESCRIPTION
cacert - cacert option to pass to curl
capath - capath option to pass to curl
insecure - allow insecure SSL connections

More details at http://curl.haxx.se/docs/sslcerts.html
