### PR TITLE
adding content_type initialization option

### DIFF
--- a/lib/chuckle/curl.rb
+++ b/lib/chuckle/curl.rb
@@ -70,7 +70,7 @@ module Chuckle
 
       if request.body
         command += ["--data-binary", request.body]
-        command += ["--header", "Content-Type: application/x-www-form-urlencoded"]
+        command += ["--header", "Content-Type: #{client.content_type}"]
       end
 
       if client.cookies?

--- a/lib/chuckle/options.rb
+++ b/lib/chuckle/options.rb
@@ -5,6 +5,7 @@ module Chuckle
       cache_errors: true,
       cacert: nil,
       capath: nil,
+      content_type: "application/x-www-form-urlencoded",
       cookies: false,
       expires_in: :never,
       insecure: false,
@@ -44,6 +45,10 @@ module Chuckle
     # capath to pass to curl
     def capath
       options[:capath]
+    end
+
+    def content_type
+      options[:content_type]
     end
 
     # are cookies enabled?


### PR DESCRIPTION
I can't get certain requests to succeed because they are throwing 415 errors, I'd like to override the hard coded Content-Type: application/x-www-form-urlencoded curl option when needed