### PR TITLE
upgrade from trollop to optimist

### DIFF
--- a/bin/chuckle
+++ b/bin/chuckle
@@ -4,7 +4,7 @@
 $VERBOSE = true
 
 require 'chuckle'
-require 'trollop'
+require 'optimist'
 
 class Main
   attr_accessor :options
@@ -33,7 +33,7 @@ end
 # parse command line
 #
 
-options = Trollop.options do
+options = Optimist::options do
   banner <<EOF
 Usage: chuckle <url_file>
 
@@ -45,6 +45,6 @@ EOF
   opt :timeout, 'Timeout per retry', type: Integer
 end
 
-Trollop.die 'need <url_file>' if ARGV.length != 1
+Optimist::die 'need <url_file>' if ARGV.length != 1
 options[:file] = ARGV.shift
 Main.new(options)

--- a/chuckle.gemspec
+++ b/chuckle.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'chuckle'
 
-  s.add_runtime_dependency 'trollop'
+  s.add_runtime_dependency 'optimist'
 
   s.add_development_dependency 'awesome_print'
   s.add_development_dependency 'json'

--- a/lib/chuckle/version.rb
+++ b/lib/chuckle/version.rb
@@ -1,4 +1,4 @@
 module Chuckle
   # Gem version
-  VERSION = '1.0.8'.freeze
+  VERSION = '1.0.9'.freeze
 end


### PR DESCRIPTION
trollop is dead... long live trollop. For some reason the trollop devs renamed their gem to "optimist" and slightly changed the api - greatly inconveniencing everyone.

hi!